### PR TITLE
 Ajusta validação dos links com awesome_bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - gem install awesome_bot
 
 script:
-  - find . -iname '*.md' -exec awesome_bot "{}" --allow-redirect --allow-ssl \;
+  - markdown_files=$(ls -m *.md); awesome_bot --files ${markdown_files//, /,} --allow-redirect --allow-ssl
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - gem install awesome_bot
 
 script:
-  - markdown_files=$(ls -m *.md); awesome_bot --files ${markdown_files//, /,} --allow-redirect --allow-ssl
+  - awesome_bot *.md  --allow-redirect --allow-ssl --allow-redirect --allow-ssl
 
 notifications:
   email: false


### PR DESCRIPTION
O comando find não exporta o `exit status` que o comando `awesome_bot` retorna, o que faz com que o Travis sempre receba um status de sucesso ao validar um link mesmo que ele não seja válido.

Por este motivo o build está como `passing` mesmo havendo links quebrados na lista..

Não tenho certeza se este comando vai funcionar, mas abri o PR para realizarmos o teste.